### PR TITLE
Add RBAC administrator configurations for workloads and update role a…

### DIFF
--- a/terraform/azure-workloads.rbac.tf
+++ b/terraform/azure-workloads.rbac.tf
@@ -1,0 +1,83 @@
+locals {
+  workload_rbac_administrator_map = {
+    for environment in local.workload_environments :
+    environment.key => [
+      for entry in try(environment.rbac_administrator, []) : {
+        workload_name          = environment.workload_name
+        environment_name       = environment.environment_name
+        service_principal_name = format("spn-%s-%s", lower(environment.workload_name), lower(environment.environment_name))
+        scope_name             = entry.scope
+        scope_id               = try(data.azurerm_subscription.subscriptions[entry.scope].id, entry.scope)
+        subscription_id        = try(data.azurerm_subscription.subscriptions[entry.scope].subscription_id, null)
+        allowed_roles          = try(entry.allowed_roles, [])
+      }
+    ]
+    if length(try(environment.rbac_administrator, [])) > 0
+  }
+
+  workload_rbac_allowed_role_map = {
+    for request in flatten([
+      for environment in local.workload_environments : [
+        for entry in try(environment.rbac_administrator, []) : [
+          for role_name in try(entry.allowed_roles, []) : {
+            key        = format("%s|%s", entry.scope, role_name)
+            scope_name = entry.scope
+            role_name  = role_name
+          }
+        ]
+      ]
+    ]) :
+    request.key => {
+      scope_name = request.scope_name
+      role_name  = request.role_name
+    }
+  }
+
+  workload_rbac_administrator_assignments = flatten([
+    for environment in local.workload_environments : [
+      for entry_index, entry in try(environment.rbac_administrator, []) : {
+        assignment_key           = format("%s-%s-%d", environment.key, replace(entry.scope, "/", "-"), entry_index)
+        workload_environment_key = environment.key
+        scope_id                 = try(data.azurerm_subscription.subscriptions[entry.scope].id, entry.scope)
+        allowed_role_keys = [
+          for role_name in try(entry.allowed_roles, []) :
+          format("%s|%s", entry.scope, role_name)
+        ]
+      }
+      if length(try(entry.allowed_roles, [])) > 0
+    ]
+  ])
+}
+
+data "azurerm_role_definition" "workload_rbac_allowed" {
+  for_each = local.workload_rbac_allowed_role_map
+
+  name  = each.value.role_name
+  scope = try(data.azurerm_subscription.subscriptions[each.value.scope_name].id, each.value.scope_name)
+}
+
+resource "azurerm_role_assignment" "workload_rbac_administrator" {
+  for_each = { for assignment in local.workload_rbac_administrator_assignments : assignment.assignment_key => assignment }
+
+  scope                = each.value.scope_id
+  role_definition_name = "Role Based Access Control Administrator"
+  principal_id         = azuread_service_principal.workload[each.value.workload_environment_key].object_id
+
+  condition_version = "2.0"
+  condition = jsonencode({
+    AllOf = [
+      {
+        AnyOf = [
+          for role_key in each.value.allowed_role_keys : {
+            Field  = "Microsoft.Authorization/roleAssignments/roleDefinitionId"
+            Equals = data.azurerm_role_definition.workload_rbac_allowed[role_key].id
+          }
+        ]
+      }
+    ]
+  })
+}
+
+output "workload_rbac_administrators" {
+  value = local.workload_rbac_administrator_map
+}

--- a/terraform/azure-workloads.tf
+++ b/terraform/azure-workloads.tf
@@ -36,6 +36,7 @@ locals {
         devops_project                  = try(environment.devops_project, null)
         devops_create_variable_group    = try(environment.devops_create_variable_group, false) || (try(environment.devops_project, null) != null && try(environment.add_deploy_script_identity, false))
         role_assignments                = try(environment.role_assignments, [])
+        rbac_administrator              = try(environment.rbac_administrator, [])
         directory_roles                 = try(environment.directory_roles, [])
         requires_terraform_state_access = try(environment.requires_terraform_state_access, [])
       }

--- a/terraform/workloads/portal/portal-repository.json
+++ b/terraform/workloads/portal/portal-repository.json
@@ -31,9 +31,18 @@
                 {
                     "scope": "sub-visualstudio-enterprise",
                     "role_definitions": [
-                        "Owner",
+                        "Contributor",
                         "Key Vault Secrets Officer",
                         "Storage Blob Data Contributor"
+                    ]
+                }
+            ],
+            "rbac_administrator": [
+                {
+                    "scope": "sub-visualstudio-enterprise",
+                    "allowed_roles": [
+                        "Key Vault Secrets User",
+                        "Storage Blob Data Owner"
                     ]
                 }
             ],
@@ -55,9 +64,18 @@
                 {
                     "scope": "sub-xi-portal-prd",
                     "role_definitions": [
-                        "Owner",
+                        "Contributor",
                         "Key Vault Secrets Officer",
                         "Storage Blob Data Contributor"
+                    ]
+                }
+            ],
+            "rbac_administrator": [
+                {
+                    "scope": "sub-xi-portal-prd",
+                    "allowed_roles": [
+                        "Key Vault Secrets User",
+                        "Storage Blob Data Owner"
                     ]
                 }
             ],


### PR DESCRIPTION
This pull request introduces support for configuring RBAC (Role-Based Access Control) administrators for Azure workloads via Terraform. The main changes include updates to the Terraform configuration and workload definitions to allow specifying RBAC administrators and their allowed roles per environment.

**RBAC Administrator Support and Configuration:**

* Added a new `rbac_administrator` property to workload environment definitions in `terraform/azure-workloads.tf` to capture RBAC administrator settings.
* Updated `portal-repository.json` to define `rbac_administrator` entries for both `sub-visualstudio-enterprise` and `sub-xi-portal-prd` scopes, specifying allowed roles for each. [[1]](diffhunk://#diff-9bfe84ba35435ca570b52cc3c72cc0b056b7aec98c0af03f013422ee75a91defL34-R48) [[2]](diffhunk://#diff-9bfe84ba35435ca570b52cc3c72cc0b056b7aec98c0af03f013422ee75a91defL58-R81)

**Terraform Logic and Resource Creation:**

* Introduced new local variables in `azure-workloads.rbac.tf` to process `rbac_administrator` entries, map allowed roles, and generate role assignment data structures.
* Added a `data.azurerm_role_definition.workload_rbac_allowed` block to look up role definitions for each allowed role.
* Created a new `azurerm_role_assignment.workload_rbac_administrator` resource to assign the "Role Based Access Control Administrator" role to the appropriate service principals, with conditions restricting them to the specified allowed roles.
* Output the computed `workload_rbac_administrator_map` for visibility and potential downstream use.…ssignments