### PR TITLE
Wire frasermolyneux-copilot MCP server into runner and clients

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,12 @@
 >
 > Note: This repository is the **origin** of the `platform-workloads` remote state that other platform stacks consume. It does not itself depend on a platform remote state.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Project Overview
 
 This is a Terraform stack that transforms JSON workload definitions into Azure AD applications, service principals with OIDC federation, GitHub repositories with environments and secrets, Azure DevOps service connections/environments/variable groups, and workload-scoped RBAC role assignments. It is an infrastructure-as-code project using HCL (Terraform) with JSON configuration files.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": [
+        "list_instructions",
+        "get_instruction",
+        "search_instructions",
+        "list_prompts",
+        "get_prompt",
+        "search_prompts",
+        "list_agents",
+        "get_agent",
+        "search_agents"
+      ]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,3 +33,16 @@ jobs:
         with:
           repository: frasermolyneux/.github-copilot
           path: .github-copilot
+          ref: refs/tags/v0.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Build MCP server
+        shell: bash
+        run: |
+          cd .github-copilot/mcp-server
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilot` at tag `v0.1.0` and builds the `frasermolyneux-copilot` MCP server so the GitHub Copilot coding agent can call it via `.github/copilot/mcp_config.json`. To wire the same server into local VS Code (or any other MCP-capable client), see the upstream `mcp-server/README.md` in [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot/blob/main/mcp-server/README.md) for the tool surface, content-root resolution, and per-client snippets.


### PR DESCRIPTION
Brings `platform-workloads` in line with the rollout already shipped to `portal-core`: the coding-agent runner now builds the shared `frasermolyneux-copilot` MCP server from `frasermolyneux/.github-copilot@v0.1.0`, and clients are pointed at it so agents prefer the live org catalog (instructions, prompts, agents) over their own assumptions.

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** — pin shared-config checkout to `refs/tags/v0.1.0`; append `actions/setup-node@<sha> # v4` (Node 20) and a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`).
- **`.github/copilot/mcp_config.json`** — new file declaring the `frasermolyneux-copilot` stdio server (node entrypoint at `.github-copilot/mcp-server/dist/index.js`, `GH_COPILOT_CONTENT_ROOT=.github-copilot`) with an explicit 9-tool surface.
- **`.github/copilot-instructions.md`** — insert the canonical `## Org conventions via MCP (when available)` section, byte-identical to the version in `portal-core`.
- **`README.md`** — append a short `## Local dev: MCP wire-up` section pointing at upstream `mcp-server/README.md` rather than duplicating its content.

## Notes for reviewers

- All four touched files were cross-checked against `frasermolyneux/portal-core@main`; the runner steps, the JSON config (including the explicit tool list), and the inserted instructions snippet are byte-equivalent to that shipped pattern.
- `AGENTS.md` does not yet exist in this repo, so the MCP section was not added there. Bootstrapping `AGENTS.md` is owned by a separate metadata pass — once it lands, the same snippet should be added there too.
- The snippet (sourced upstream via MCP) still says "seven tools total" while the config now lists nine; that wording quirk is preserved verbatim from `portal-core` and should be fixed upstream in `frasermolyneux/.github-copilot`'s `metadata.copilot-instructions` source-of-truth rather than diverging here.
- No Terraform changes; CI plan jobs should be a no-op against this branch.