### PR TITLE
feat(dev-platform): add github-copilot workload

### DIFF
--- a/terraform/workloads/dev-platform/github-copilot.json
+++ b/terraform/workloads/dev-platform/github-copilot.json
@@ -1,0 +1,221 @@
+{
+    "name": "github-copilot",
+    "github": {
+        "description": "Org Copilot catalog + hosted HTTP MCP server (Azure Container Apps)",
+        "topics": [
+            "copilot",
+            "mcp",
+            "azure",
+            "terraform",
+            "github-actions"
+        ],
+        "visibility": "public",
+        "has_downloads": false,
+        "has_issues": true,
+        "has_projects": false,
+        "has_wiki": false,
+        "add_sonarcloud_secrets": false,
+        "add_nuget_environment": false,
+        "rulesets": [
+            {
+                "name": "main-protection",
+                "target": "branch",
+                "enforcement": "active",
+                "includes": [
+                    "refs/heads/main"
+                ],
+                "excludes": [],
+                "bypass_actors": [
+                    {
+                        "bypass_mode": "always",
+                        "actor_id": 5,
+                        "actor_type": "RepositoryRole"
+                    }
+                ],
+                "rules": {
+                    "required_status_checks": [
+                        {
+                            "context": "terraform-plan-dev",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "devops-secure-scanning / DevOps Secure Scanning",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "mcp-server-ci",
+                            "integration_id": 15368
+                        }
+                    ],
+                    "strict_required_status_checks_policy": true,
+                    "do_not_enforce_on_create": false,
+                    "pull_request": {
+                        "allowed_merge_methods": [
+                            "merge",
+                            "rebase",
+                            "squash"
+                        ],
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": true,
+                        "require_code_owner_review": false,
+                        "required_review_thread_resolution": true
+                    },
+                    "required_code_scanning": [],
+                    "copilot_code_review": {
+                        "review_draft_pull_requests": true,
+                        "review_on_push": true
+                    },
+                    "required_signatures": false,
+                    "required_linear_history": true,
+                    "non_fast_forward": true
+                }
+            }
+        ],
+        "labels": [
+            {
+                "name": "deploy-dev",
+                "description": "Run dev Terraform plan+apply and deploy",
+                "color": "0E8A16"
+            },
+            {
+                "name": "run-prd-plan",
+                "description": "Run prd Terraform plan",
+                "color": "5319E7"
+            }
+        ]
+    },
+    "environments": [
+        {
+            "name": "Development",
+            "subscription": "sub-visualstudio-enterprise",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "requires_terraform_state_access": [
+                "platform-registry",
+                "platform-monitoring",
+                "platform-connectivity"
+            ],
+            "locations": [
+                "uksouth"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "AcrPull"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "directory_roles": [
+                "Directory Readers"
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "roles": [
+                            "Reader"
+                        ]
+                    },
+                    {
+                        "scope": "workload:platform-monitoring/Development",
+                        "roles": [
+                            "Monitoring Reader",
+                            "Log Analytics Contributor"
+                        ]
+                    },
+                    {
+                        "scope": "workload:platform-registry/Development",
+                        "roles": [
+                            "AcrPull"
+                        ]
+                    },
+                    {
+                        "scope": "/subscriptions/db34f572-8b71-40d6-8f99-f29a27612144/resourceGroups/rg-platform-dns-prd-uksouth-01",
+                        "roles": [
+                            "DNS Zone Contributor"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Production",
+            "subscription": "sub-platform-shared",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "requires_terraform_state_access": [
+                "platform-registry",
+                "platform-monitoring",
+                "platform-connectivity"
+            ],
+            "locations": [
+                "uksouth"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "AcrPull"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "directory_roles": [
+                "Directory Readers"
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "roles": [
+                            "Reader"
+                        ]
+                    },
+                    {
+                        "scope": "workload:platform-monitoring/Production",
+                        "roles": [
+                            "Monitoring Reader",
+                            "Log Analytics Contributor"
+                        ]
+                    },
+                    {
+                        "scope": "workload:platform-registry/Production",
+                        "roles": [
+                            "AcrPull"
+                        ]
+                    },
+                    {
+                        "scope": "/subscriptions/db34f572-8b71-40d6-8f99-f29a27612144/resourceGroups/rg-platform-dns-prd-uksouth-01",
+                        "roles": [
+                            "DNS Zone Contributor"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Why

Phase 1 of moving the org-wide GitHub Copilot MCP integration from a per-repo stdio MCP wire-up (git clone + npm ci + npm run build in every CI run, fragile) to a hosted HTTP MCP server on Azure Container Apps. This PR provisions the workload identity, resource groups, and Terraform state backend so the upcoming `frasermolyneux/github-copilot` infra PR has somewhere to land.

## What

Adds a single workload definition: `terraform/workloads/dev-platform/github-copilot.json`.

- Placed under `dev-platform/` (alongside `api-client-abstractions`, `observability-appinsights`, `observability-opentelemetry`) rather than `platform/`, because this is developer tooling, not horizontal platform infrastructure that other workloads consume.
- Dev (`sub-visualstudio-enterprise`) and Prd (`sub-platform-shared`) environments, both `uksouth`, modelled on `platform-registry.json`.
- Ruleset mirrors `platform-registry.json` verbatim with an additional `mcp-server-ci` required status check alongside `terraform-plan-dev` and `devops-secure-scanning`.
- Workload RG `rg-{workload}-{env}-{location}` with `Contributor` assigned and `AcrPull` rbac_admin delegation so the Container App runtime managed identity can be granted pull access within the workload's own RG.
- `requires_terraform_state_access` on both envs for `platform-registry`, `platform-monitoring`, `platform-connectivity` — to read the ACR resource ID, App Insights connection string output, and DNS zone for the planned `mcp.frasermolyneux.dev` custom domain.
- Paired cross-workload `role_assignments` following the `portal-server-agent` and `platform-notifications` pattern: `Monitoring Reader` + `Log Analytics Contributor` on `platform-monitoring`, `AcrPull` on `platform-registry`, and `DNS Zone Contributor` on the platform DNS RG (`rg-platform-dns-prd-uksouth-01`).

## Review notes

- The `mcp-server-ci` status check name will not resolve until the consumer repo wires up its workflow. This is consistent with how `platform-registry.json` already requires `terraform-plan-dev` ahead of consumer wiring.
- **AcrPull vs AcrPush.** This workload is granted `AcrPull` on `workload:platform-registry/<env>`. The only other Container Apps workload in this repo, `portal-server-agent`, uses `AcrPush` because its CI builds and pushes images. If `github-copilot`'s CI will publish container images itself, this needs to be flipped to `AcrPush` (in both `assigned_roles` and `rbac_admin_roles.allowed_roles`). Leaving as Pull pending confirmation of who publishes the image.
- No import block. The existing unmanaged `frasermolyneux/.github-copilot` repository is intentionally not adopted by this PR; first apply will create a fresh `frasermolyneux/github-copilot`, and the old `.github-copilot` repo will be retired separately.

## Verification

- `ConvertFrom-Json` parses cleanly.
- `terraform fmt -check -recursive` exits 0.
- `terraform validate` exits 0 (only the pre-existing `vulnerability_alerts` deprecation warning, unrelated).
- Code review: no High findings; one Medium surfaced about AcrPull vs AcrPush, captured above for explicit decision.