### PR TITLE
Fix(github-copilot): grant AcrPush for image publish

### DIFF
--- a/terraform/workloads/dev-platform/github-copilot.json
+++ b/terraform/workloads/dev-platform/github-copilot.json
@@ -112,7 +112,7 @@
                         "rbac_admin_roles": [
                             {
                                 "allowed_roles": [
-                                    "AcrPull"
+                                    "AcrPush"
                                 ]
                             }
                         ]
@@ -139,7 +139,7 @@
                     {
                         "scope": "workload:platform-registry/Development",
                         "roles": [
-                            "AcrPull"
+                            "AcrPush"
                         ]
                     },
                     {
@@ -178,7 +178,7 @@
                         "rbac_admin_roles": [
                             {
                                 "allowed_roles": [
-                                    "AcrPull"
+                                    "AcrPush"
                                 ]
                             }
                         ]
@@ -205,7 +205,7 @@
                     {
                         "scope": "workload:platform-registry/Production",
                         "roles": [
-                            "AcrPull"
+                            "AcrPush"
                         ]
                     },
                     {


### PR DESCRIPTION
## Summary

Follow-up to #162. Flips every `AcrPull` reference for the `github-copilot` workload's `platform-registry` scope to `AcrPush`.

## Rationale

The `github-copilot` MCP server's CI in [frasermolyneux/github-copilot](https://github.com/frasermolyneux/github-copilot) builds and pushes container images to the shared platform ACR. Its workload SPN therefore needs **push** rights (not just pull) at the SPN scope so the CI workflow can publish images.

This mirrors the existing `portal-server-agent` workload pattern.

## Changes

Four lines flipped in `terraform/workloads/dev-platform/github-copilot.json` (one pair per environment — Development and Production):

1. `environments[*].role_assignments.assigned_roles[]` where `scope == "workload:platform-registry/<env>"` → `roles: ["AcrPush"]`
2. `environments[*].resource_groups[*].role_assignments.rbac_admin_roles[].allowed_roles` → `["AcrPush"]`

## Validation

- ✅ JSON parses (`ConvertFrom-Json`)
- ✅ `terraform fmt -check -recursive`
- ✅ `terraform validate` (only pre-existing unrelated `vulnerability_alerts` deprecation warning)
- ✅ `git diff` shows exactly 4 changed lines

Add the `run-prd-plan` label to surface the production plan in CI.