### PR TITLE
feat: add platform-status-web workload

### DIFF
--- a/terraform/workloads/platform/platform-status-web.json
+++ b/terraform/workloads/platform/platform-status-web.json
@@ -1,0 +1,209 @@
+{
+    "name": "platform-status-web",
+    "github": {
+        "description": "Public status pages for frasermolyneux platforms (XtremeIdiots, Molyneux personal). Generic multi-site app reading App Insights availability telemetry + GitHub Issues, served via Azure Static Web Apps.",
+        "topics": [
+            "azure",
+            "terraform",
+            "github-actions",
+            "azure-functions",
+            "azure-static-web-apps",
+            "status-page",
+            "availability",
+            "monitoring"
+        ],
+        "visibility": "public",
+        "add_sonarcloud_secrets": true,
+        "rulesets": [
+            {
+                "name": "main-protection",
+                "target": "branch",
+                "enforcement": "active",
+                "includes": [
+                    "refs/heads/main"
+                ],
+                "excludes": [],
+                "bypass_actors": [
+                    {
+                        "bypass_mode": "always",
+                        "actor_id": 5,
+                        "actor_type": "RepositoryRole"
+                    }
+                ],
+                "rules": {
+                    "required_status_checks": [
+                        {
+                            "context": "SonarCloud Code Analysis",
+                            "integration_id": 12526
+                        },
+                        {
+                            "context": "build-and-test",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "quality / Code Quality",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "devops-secure-scanning / DevOps Secure Scanning",
+                            "integration_id": 15368
+                        }
+                    ],
+                    "strict_required_status_checks_policy": true,
+                    "do_not_enforce_on_create": false,
+                    "pull_request": {
+                        "allowed_merge_methods": [
+                            "merge",
+                            "rebase",
+                            "squash"
+                        ],
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": true,
+                        "require_code_owner_review": false,
+                        "required_review_thread_resolution": true
+                    },
+                    "required_code_scanning": [
+                        {
+                            "tool": "CodeQL",
+                            "alerts_threshold": "errors",
+                            "security_alerts_threshold": "high_or_higher"
+                        },
+                        {
+                            "tool": "SonarCloud",
+                            "alerts_threshold": "errors",
+                            "security_alerts_threshold": "high_or_higher"
+                        }
+                    ],
+                    "copilot_code_review": {
+                        "review_draft_pull_requests": true,
+                        "review_on_push": true
+                    },
+                    "required_signatures": false,
+                    "required_linear_history": true,
+                    "non_fast_forward": true
+                }
+            }
+        ],
+        "labels": [
+            {
+                "name": "deploy-dev",
+                "description": "Run dev Terraform plan+apply and deploy the app",
+                "color": "0E8A16"
+            },
+            {
+                "name": "run-prd-plan",
+                "description": "Run prd Terraform plan",
+                "color": "5319E7"
+            }
+        ]
+    },
+    "environments": [
+        {
+            "name": "Development",
+            "subscription": "sub-visualstudio-enterprise",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "locations": [
+                "swedencentral"
+            ],
+            "requires_terraform_state_access": [
+                "platform-monitoring"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor",
+                                    "Key Vault Secrets Officer"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "Key Vault Secrets User",
+                                    "Storage Blob Data Contributor",
+                                    "Monitoring Reader"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "roles": [
+                            "Reader"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Production",
+            "subscription": "sub-platform-management",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "locations": [
+                "swedencentral"
+            ],
+            "requires_terraform_state_access": [
+                "platform-monitoring"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor",
+                                    "Key Vault Secrets Officer"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "Key Vault Secrets User",
+                                    "Storage Blob Data Contributor",
+                                    "Monitoring Reader"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "scope": "sub-xi-portal-prd",
+                        "roles": [
+                            "Reader",
+                            "Monitoring Reader"
+                        ]
+                    },
+                    {
+                        "scope": "sub-platform-shared",
+                        "roles": [
+                            "Reader",
+                            "Monitoring Reader"
+                        ]
+                    }
+                ],
+                "rbac_admin_roles": [
+                    {
+                        "scope": "sub-platform-management",
+                        "allowed_roles": [
+                            "Monitoring Reader"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds a new `platform-status-web` workload definition for the public status pages app (XtremeIdiots, Molyneux personal). Provisions the GitHub repo, OIDC-federated service principals, and Dev/Prd environments in Sweden Central.

## Type of change

- [x] New workload / feature
- [ ] Bug fix
- [ ] Refactor / chore
- [ ] Docs only

## What changed

- New file: `terraform/workloads/platform/platform-status-web.json`
- Dev env → `sub-visualstudio-enterprise`, Sweden Central
- Prd env → `sub-platform-management`, Sweden Central (same sub as `platform-monitoring`)
- Both envs: `requires_terraform_state_access: ["platform-monitoring"]` (status app emits to the central LA workspace)
- RG `role_assignments`: `Contributor` + `Key Vault Secrets Officer` (assigned); `rbac_admin_roles` allowing `Key Vault Secrets User`, `Storage Blob Data Contributor`, `Monitoring Reader`
- Prd env-level cross-sub: `Reader` + `Monitoring Reader` on `sub-xi-portal-prd` and `sub-platform-shared` — required so the future Function App MI can read availability telemetry from sitewatch / portal App Insights resources
- Prd env-level `rbac_admin_roles` with explicit `scope: sub-platform-management` allowing `Monitoring Reader` — lets the deploy identity delegate `Monitoring Reader` to a Function App MI living in a different RG within the same sub
- Web-app style ruleset (`build-and-test`, `SonarCloud Code Analysis`, `quality / Code Quality`, `devops-secure-scanning`) matching `platform-sitewatch-func`

## Validation evidence

```
PS> terraform -chdir=terraform fmt -check -recursive
(no output, exit 0)

PS> terraform -chdir=terraform init -backend=false
Terraform has been successfully initialized!

PS> terraform -chdir=terraform validate
Warning: Argument is deprecated
  with github_repository.workload, on azure-workloads.tf line 16
  16:   vulnerability_alerts = true
Success! The configuration is valid, but there were some validation warnings as shown above.
```

The `vulnerability_alerts` deprecation warning is pre-existing in `azure-workloads.tf` and unrelated to this change.

### Schema verdict on the sub-scoped `rbac_admin_roles` entry

Supported. `terraform/azure-workloads.rbac.tf` reads env-level entries via `try(entry.scope, null)` and `coalesce(try(entry.scope, null), environment.subscription)`, applying the same `sub-*` alias resolution used elsewhere — so `scope: "sub-platform-management"` on an env-level `rbac_admin_roles` entry resolves cleanly. No JSON schema file exists in the repo; `terraform validate` is the source of truth and it passes.

## Risk and rollout

- **Blast radius**: new resources only (new GitHub repo, two new service principals, two new RGs, federated credentials, RBAC). No existing workload modified.
- **Auto-deploy**: no — `run-prd-plan` label applied so prd plan runs in CI for review before merge.
- **Manual post-merge steps**:
  - Create the SonarCloud project for the new repo (matches the pattern for other `add_sonarcloud_secrets: true` workloads).
- **Rollback**: revert the PR before any prd apply; if applied, follow `docs/decommissioning.md` (Decommission State Rm workflow → delete JSON → PR).

## Agent attestation

- [x] Read `.github/copilot-instructions.md` and relevant `.github-copilot/` instructions
- [x] No client secrets, connection strings, or hard-coded GUIDs introduced
- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes (only pre-existing deprecation warning)
- [x] Naming/tagging conventions preserved (`spn-{workload}-{env}`, `rg-{workload}-{env}-{location}`)
- [x] OIDC-only auth (no `client_secret` paths)
- [x] No `.github/workflows/`, `version.json`, or platform consumption wiring touched

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>