### PR TITLE
Add trip-side-kick workload definition

### DIFF
--- a/terraform/directory-roles.tf
+++ b/terraform/directory-roles.tf
@@ -4,7 +4,9 @@ locals {
     "Directory Writers",
     "Cloud application administrator",
     "Groups Administrator",
-    "Application Administrator"
+    "Application Administrator",
+    "External ID User Flow Administrator",
+    "External Identity Provider Administrator"
   ]
 }
 

--- a/terraform/workloads/trip-side-kick/trip-side-kick.json
+++ b/terraform/workloads/trip-side-kick/trip-side-kick.json
@@ -1,0 +1,261 @@
+{
+    "name": "trip-side-kick",
+    "github": {
+        "description": "Trip Side Kick travel-itinerary PWA and API/BFF with Microsoft Entra External ID sign-in (B2B + self-service sign-up), Azure SQL, and private Blob Storage, deployed with Terraform and GitHub Actions.",
+        "topics": [
+            "react",
+            "pwa",
+            "typescript",
+            "aspnet-core",
+            "dotnet",
+            "entra-external-id",
+            "azure-sql",
+            "app-service",
+            "blob-storage",
+            "cloudflare",
+            "terraform",
+            "github-actions"
+        ],
+        "add_sonarcloud_secrets": true,
+        "visibility": "public",
+        "rulesets": [
+            {
+                "name": "main-protection",
+                "target": "branch",
+                "enforcement": "active",
+                "includes": [
+                    "refs/heads/main"
+                ],
+                "excludes": [],
+                "bypass_actors": [
+                    {
+                        "bypass_mode": "always",
+                        "actor_id": 5,
+                        "actor_type": "RepositoryRole"
+                    }
+                ],
+                "rules": {
+                    "required_status_checks": [
+                        
+                        {
+                            "context": "dependabot-policy",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "SonarCloud Code Analysis",
+                            "integration_id": 12526
+                        },
+                        {
+                            "context": "build-and-test",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "quality / Code Quality",
+                            "integration_id": 15368
+                        },
+                        {
+                            "context": "devops-secure-scanning / DevOps Secure Scanning",
+                            "integration_id": 15368
+                        }
+                    ],
+                    "strict_required_status_checks_policy": true,
+                    "do_not_enforce_on_create": false,
+                    "pull_request": {
+                        "allowed_merge_methods": [
+                            "merge",
+                            "rebase",
+                            "squash"
+                        ],
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": true,
+                        "require_code_owner_review": false,
+                        "required_review_thread_resolution": true
+                    },
+                    "required_code_scanning": [
+                        {
+                            "tool": "CodeQL",
+                            "alerts_threshold": "errors",
+                            "security_alerts_threshold": "high_or_higher"
+                        },
+                        {
+                            "tool": "SonarCloud",
+                            "alerts_threshold": "errors",
+                            "security_alerts_threshold": "high_or_higher"
+                        }
+                    ],
+                    "copilot_code_review": {
+                        "review_draft_pull_requests": true,
+                        "review_on_push": true
+                    },
+                    "required_signatures": false,
+                    "required_linear_history": true,
+                    "non_fast_forward": true
+                }
+            }
+        ],
+        "labels": [
+            {
+                "name": "deploy-dev",
+                "description": "Run dev Terraform plan+apply and deploy the app",
+                "color": "0E8A16"
+            },
+            {
+                "name": "run-prd-plan",
+                "description": "Run prd Terraform plan",
+                "color": "5319E7"
+            }
+        ]
+    },
+    "environments": [
+        {
+            "name": "Development",
+            "subscription": "sub-visualstudio-enterprise",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "requires_terraform_state_access": [
+                "platform-hosting",
+                "platform-monitoring"
+            ],
+            "locations": [
+                "swedencentral"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "Key Vault Secrets User",
+                                    "Key Vault Secrets Officer",
+                                    "Storage Blob Data Contributor"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "directory_roles": [
+                "Cloud application administrator",
+                "Directory Readers",
+                "External ID User Flow Administrator",
+                "External Identity Provider Administrator"
+            ],
+            "graph_api_permissions": [
+                "Application.ReadWrite.OwnedBy",
+                "Policy.ReadWrite.AuthenticationFlows",
+                "IdentityUserFlow.ReadWrite.All",
+                "IdentityProvider.ReadWrite.All"
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "scope": "workload-rg:platform-hosting/development/rg-platform-hosting-dev-swedencentral/swedencentral",
+                        "roles": [
+                            "Contributor"
+                        ]
+                    }
+                ]
+            },
+            "cloudflare_tokens": [
+                {
+                    "name_suffix": "dns",
+                    "policies": [
+                        {
+                            "permission_groups": [
+                                "DNS Write",
+                                "Zone Read"
+                            ],
+                            "zones": [
+                                "tripsidekick.app",
+                                "tripsidekick.net"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Production",
+            "subscription": "sub-platform-shared",
+            "connect_to_github": true,
+            "configure_for_terraform": true,
+            "requires_terraform_state_access": [
+                "platform-hosting",
+                "platform-monitoring"
+            ],
+            "locations": [
+                "swedencentral"
+            ],
+            "resource_groups": [
+                {
+                    "name": "rg-{workload}-{env}-{location}",
+                    "role_assignments": {
+                        "assigned_roles": [
+                            {
+                                "roles": [
+                                    "Contributor"
+                                ]
+                            }
+                        ],
+                        "rbac_admin_roles": [
+                            {
+                                "allowed_roles": [
+                                    "Key Vault Secrets User",
+                                    "Key Vault Secrets Officer",
+                                    "Storage Blob Data Contributor"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "directory_roles": [
+                "Cloud application administrator",
+                "Directory Readers",
+                "External ID User Flow Administrator",
+                "External Identity Provider Administrator"
+            ],
+            "graph_api_permissions": [
+                "Application.ReadWrite.OwnedBy",
+                "Policy.ReadWrite.AuthenticationFlows",
+                "IdentityUserFlow.ReadWrite.All",
+                "IdentityProvider.ReadWrite.All"
+            ],
+            "role_assignments": {
+                "assigned_roles": [
+                    {
+                        "scope": "workload-rg:platform-hosting/production/rg-platform-hosting-prd-swedencentral/swedencentral",
+                        "roles": [
+                            "Contributor"
+                        ]
+                    }
+                ]
+            },
+            "cloudflare_tokens": [
+                {
+                    "name_suffix": "dns",
+                    "policies": [
+                        {
+                            "permission_groups": [
+                                "DNS Write",
+                                "Zone Read"
+                            ],
+                            "zones": [
+                                "tripsidekick.app",
+                                "tripsidekick.net"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Add the `trip-side-kick` platform-workloads definition provisioning the GitHub repo, dev/prd workload identities, resource groups, Terraform state, shared platform-hosting access, Cloudflare DNS tokens, and Entra External ID permissions for future customer sign-in automation.

## Type of change
- [x] New feature / capability

## Details
- New `terraform/workloads/trip-side-kick/trip-side-kick.json` (own-domain project, dedicated folder mirroring `geo-location`).
- Public repo, `main-protection` ruleset, SonarCloud secrets, `deploy-dev`/`run-prd-plan` labels; no NuGet environment.
- Development (`sub-visualstudio-enterprise`) + Production (`sub-platform-shared`), both `swedencentral`, `connect_to_github` + `configure_for_terraform`, own `rg-{workload}-{env}-{location}` with Contributor.
- `requires_terraform_state_access`: `platform-hosting`, `platform-monitoring` (connectivity intentionally excluded — DNS is written via Cloudflare token, not connectivity outputs).
- Contributor on the shared `platform-hosting` RG per environment via `workload-rg:` scope.
- `cloudflare_tokens`: one token per environment covering `tripsidekick.app` + `tripsidekick.net` (`DNS Write`, `Zone Read`) using the `zones` array form — Cloudflare-managed DNS, no Azure DNS zone role.
- `directory_roles`: baseline `Cloud application administrator` + `Directory Readers`, plus `External ID User Flow Administrator` and `External Identity Provider Administrator` for self-service sign-up / identity provider management.
- `graph_api_permissions`: `Application.ReadWrite.OwnedBy`, `Policy.ReadWrite.AuthenticationFlows`, `IdentityUserFlow.ReadWrite.All`, `IdentityProvider.ReadWrite.All` (each least-privileged per Microsoft Graph docs).
- `terraform/directory-roles.tf`: additive — appended the two new External ID roles to `directory_roles_builtin` so the JSON references resolve. Set-based `for_each`, non-breaking for existing workloads.

## Deferred follow-ups (not in this PR)
- `tripsidekick.net` notification `email.sender` app role — pending platform-notifications onboarding the domain.
- GCP / Google Maps `gcp` block — needs a pre-created GCP project.
- Google / other social IdPs — manual OAuth consent-screen work.
- Repo bootstrap session owns the Entra External ID automation (self-service sign-up user flow, provider attachments) plus one-time admin-consent grant and tenant self-service sign-up enablement. No Conditional Access changes required.

## Validation evidence
- JSON well-formedness: `Get-Content ... | ConvertFrom-Json` -> `JSON OK`
- `terraform fmt -check -recursive -diff` -> no output (clean)
- `terraform init -backend=false` + `terraform validate` -> `Success! The configuration is valid` (one pre-existing unrelated `vulnerability_alerts` deprecation warning in azure-workloads.tf)
- `code-review` sub-agent -> no High/Medium/Low findings

## Risk and rollout
- Blast radius: creates a new workload (repo, identities, RGs, state, RBAC, Cloudflare tokens). No changes to existing workloads; `directory-roles.tf` change is purely additive.
- Auto-deploy: applied by platform-workloads prd release on merge to main.
- Manual steps post-merge: one-time Graph admin-consent grant for the four application permissions; enable tenant self-service sign-up. Handled in the downstream repo bootstrap session.
- Rollback: revert this PR (note the `github_repository.workload` `prevent_destroy` lifecycle — use the Decommission State Rm workflow if the repo was already created).

## Agent attestation
- [x] Build/validation succeeds (terraform fmt/validate)
- [x] No new secrets / GUIDs / connection strings introduced
- [x] Changes align with stack guardrails and sibling workload conventions
- [x] code-review sub-agent run; no findings to resolve
