### PR TITLE
fix: register both plain and immutable GitHub OIDC subjects for workload FICs

### DIFF
--- a/terraform/azure-workloads.if-github.tf
+++ b/terraform/azure-workloads.if-github.tf
@@ -3,6 +3,21 @@ moved {
   to   = azuread_application_federated_identity_credential.github_workload
 }
 
+// GitHub's OIDC `sub` claim format depends on when the repository was created:
+// - Repositories created before GitHub's immutable-subject rollout (2026-07-15) keep the
+//   legacy "repo:{owner}/{repo}:environment:{env}" format unless they explicitly opt in.
+// - Repositories created after that date default to the immutable
+//   "repo:{owner}@{owner_id}/{repo}@{repo_id}:environment:{env}" format, and this cannot be
+//   reliably forced back to the legacy format via the repo-level OIDC customization API
+//   (verified empirically against api.github.com/repos/frasermolyneux/trip-side-kick/actions/oidc/customization/sub -
+//   `use_immutable_subject: false` did not change the effective subject prefix).
+// We therefore register BOTH subject formats as federated credentials so a workload's
+// service principal authenticates correctly regardless of which subject GitHub presents.
+data "github_organization" "current" {
+  name         = "frasermolyneux"
+  summary_only = true // we only need .id; avoid the provider enumerating every repo/member in the org
+}
+
 resource "azuread_application_federated_identity_credential" "github_workload" {
   for_each = { for each in local.workload_environments : each.key => each if each.connect_to_github }
 
@@ -12,6 +27,23 @@ resource "azuread_application_federated_identity_credential" "github_workload" {
   audiences      = ["api://AzureADTokenExchange"]
   issuer         = "https://token.actions.githubusercontent.com"
   subject        = format("repo:frasermolyneux/%s:environment:%s", lower(each.value.workload_name), each.value.environment_name)
+}
+
+resource "azuread_application_federated_identity_credential" "github_workload_immutable" {
+  for_each = { for each in local.workload_environments : each.key => each if each.connect_to_github }
+
+  application_id = azuread_application.workload[each.key].id
+  display_name   = format("github-%s-%s-immutable", lower(each.value.workload_name), lower(each.value.environment_name))
+  description    = "GitHub Actions (immutable subject claim - see comment on github_workload)"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject = format(
+    "repo:frasermolyneux@%s/%s@%s:environment:%s",
+    data.github_organization.current.id,
+    github_repository.workload[each.value.workload_name].name,
+    github_repository.workload[each.value.workload_name].repo_id,
+    each.value.environment_name
+  )
 }
 
 resource "github_repository_environment" "workload" {

--- a/terraform/azure-workloads.if-github.tf
+++ b/terraform/azure-workloads.if-github.tf
@@ -13,9 +13,10 @@ moved {
 //   `use_immutable_subject: false` did not change the effective subject prefix).
 // We therefore register BOTH subject formats as federated credentials so a workload's
 // service principal authenticates correctly regardless of which subject GitHub presents.
-data "github_organization" "current" {
-  name         = "frasermolyneux"
-  summary_only = true // we only need .id; avoid the provider enumerating every repo/member in the org
+// frasermolyneux is a personal user account, not a GitHub organization, so the
+// `github_organization` data source (which reads /orgs/{name}) 404s here - use `github_user`.
+data "github_user" "current" {
+  username = "frasermolyneux"
 }
 
 resource "azuread_application_federated_identity_credential" "github_workload" {
@@ -39,7 +40,7 @@ resource "azuread_application_federated_identity_credential" "github_workload_im
   issuer         = "https://token.actions.githubusercontent.com"
   subject = format(
     "repo:frasermolyneux@%s/%s@%s:environment:%s",
-    data.github_organization.current.id,
+    data.github_user.current.id,
     github_repository.workload[each.value.workload_name].name,
     github_repository.workload[each.value.workload_name].repo_id,
     each.value.environment_name


### PR DESCRIPTION
## Summary

Fixes a blocking OIDC federation bug that prevents newly-created repositories (starting with `trip-side-kick`) from authenticating to Azure in GitHub Actions.

## Root cause

GitHub changed the default OIDC `sub` claim format for **repositories created after 2026-07-15**: it now uses an immutable format that embeds numeric owner/repo IDs (`repo:owner@owner_id/repo@repo_id:environment:Env`) instead of the legacy plain format (`repo:owner/repo:environment:Env`). Existing repositories keep presenting the plain format unless they explicitly opt in.

Our `azuread_application_federated_identity_credential.github_workload` resource only registered the plain-format subject, so `trip-side-kick`'s CI fails at Azure login with:

```
AADSTS700213: No matching federated identity record found for presented assertion subject
'repo:frasermolyneux@34033625/trip-side-kick@1320673226:environment:Development'.
```

Verified via the GitHub REST API:
- `trip-side-kick` (created 2026-08-02) → immutable subject prefix
- `geo-location` (created 2022) → plain subject prefix
- Attempting to force `trip-side-kick` back to the plain format via `PUT .../actions/oidc/customization/sub` with `use_immutable_subject: false` did **not** change its effective subject — confirming the legacy format can't be reliably re-forced for post-cutoff repos.

## Fix

Since neither "pin everyone to plain" nor "migrate everyone to immutable" is safe/reliable on its own (existing repos still present plain; new repos can't be reliably forced back to plain), this adds a **second federated identity credential per workload environment** using the immutable subject format, alongside the existing plain one. Each workload's Azure AD app now trusts both subject formats, so authentication succeeds regardless of which one GitHub presents for a given repo — no per-repo special-casing needed.

Changed file: [`terraform/azure-workloads.if-github.tf`](terraform/azure-workloads.if-github.tf)
- Added `data "github_organization" "current"` (summary_only, to source the numeric owner ID cheaply)
- Added `azuread_application_federated_identity_credential.github_workload_immutable`, mirroring the existing `github_workload` resource but with the immutable subject format

Resulting FICs for `trip-side-kick`:
- Plain: `repo:frasermolyneux/trip-side-kick:environment:Development` / `...:environment:Production` (unused by this repo, harmless)
- Immutable (new): `repo:frasermolyneux@34033625/trip-side-kick@1320673226:environment:Development` / `...:environment:Production` — matches what GitHub actually presents

## Impact on existing repos

Every workload with `connect_to_github = true` gains one additional FIC per environment (2 total per app, well under Azure AD's 20-per-app limit). Existing plain-format FICs are untouched, so no currently-working repo is affected.

Branch/PR-scoped subjects were not added — `trip-side-kick`'s workflows only use `environment:`-scoped jobs for Azure login, so environment FICs fully cover its needs.

## Validation

```
terraform fmt -check -recursive   # clean
terraform init -backend=false     # ok
terraform validate                # Success (1 pre-existing unrelated deprecation warning)
```

No `terraform apply`/`plan` was run against real state — this repo's convention is to apply via its own pipeline after merge.

Ran the `code-review` sub-agent on the diff: it flagged the `github_organization` data source doing unnecessary full org/member enumeration since only `.id` is used — fixed by adding `summary_only = true`.

## Follow-up

After merge and the platform-workloads prd pipeline applies this change, re-run `trip-side-kick` PR #2's `terraform-plan-dev` / `terraform-state-check-dev` jobs to confirm green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
